### PR TITLE
update interview instructions and scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ npm run db:studio      # Database GUI
 **Requirements:**
 
 - Call Ollama API with document text using local model
-- Extract and return: summary, comprehensionScore, isNonFiction
-- Update the Document page to display the document alongside the AI generated insights. Use your judgement to make the UI useful and usable. Feel free to add whatever styling library you would like to use.
+- Extract and return: `summary`, `comprehensionScore` (0–100), `isNonFiction` (boolean), and `suggestedEdits` (array of 2–3 actionable suggestions to improve the document's clarity)
+- On the document detail page, display all four fields. `suggestedEdits` should render as a list where each suggestion can be individually marked as applied — track applied state with `useState`. Applied suggestions should look visually distinct from unapplied ones.
+- Use your judgement to make the UI useful and usable. Chakra UI is already installed.
 
 **Local API:** Uses Ollama running on `http://localhost:11434`
 
@@ -126,7 +127,7 @@ export const insights = sqliteTable('insights', {
 2. **Generate and run the migration** `npm run db:generate && npm run db:migrate`
 3. **Update store-insights API** to store all generated insights (summary, comprehensionScore, isNonFiction). This API should be called after insights are generated in Part 1.
 4. **Update get-all-insights API** to return all insight fields
-5. **Implement sorting** on the documents list on the home page (`app/page.tsx`) to show documents with lower comprehension scores first (documents that need better explanations)
+5. **Wire up the sort button** in `app/page.tsx` — the button and state are already scaffolded. Sort the documents list by comprehension score using the `sortAsc` state, toggling between ascending and descending.
 
 ### **Part 3: Architecture**
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export const insights = sqliteTable('insights', {
 ```
 
 2. **Generate and run the migration** `npm run db:generate && npm run db:migrate`
-3. **Update store-insights API** to store all generated insights (summary, comprehensionScore, isNonFiction). This API should be called after insights are generated in Part 1.
+3. **Update store-insights API** to store all generated insights (summary, comprehensionScore, isNonFiction, suggestedEdits). This API should be called after insights are generated in Part 1.
 4. **Update get-all-insights API** to return all insight fields
 5. **Wire up the sort button** in `app/page.tsx` — the button and state are already scaffolded. Sort the documents list by comprehension score using the `sortAsc` state, toggling between ascending and descending.
 

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -5,6 +5,7 @@ export interface InsightsResponse {
   summary: string
   comprehensionScore: number
   isNonFiction: boolean
+  suggestedEdits: string[]
 }
 
 export async function POST(request: NextRequest) {
@@ -17,7 +18,7 @@ export async function POST(request: NextRequest) {
   // TODO: Replace this mock implementation with Ollama API integration
   // The candidate should implement:
   // 1. Call Ollama API with the document text using a local model
-  // 2. Parse response to extract summary, comprehensionScore, and isNonFiction
+  // 2. Parse response to extract summary, comprehensionScore, isNonFiction, and suggestedEdits
   // 3. Return formatted response
 
   const ollamaHost = process.env.OLLAMA_HOST || 'http://localhost:11434'

--- a/app/api/store-insights/route.ts
+++ b/app/api/store-insights/route.ts
@@ -17,31 +17,35 @@ export async function POST(request: NextRequest) {
 
     const now = new Date()
 
-    const result = await db
-      .insertInto('insights')
-      .values({
-        documentId,
-        summary,
-        createdAt: now.getTime(),
-        updatedAt: now.getTime(),
-      })
-      .onConflict((oc) =>
-        oc.column('documentId').doUpdateSet({
+    const existing = await db
+      .selectFrom('insights')
+      .where('documentId', '=', documentId)
+      .selectAll()
+      .executeTakeFirst()
+
+    if (existing) {
+      await db
+        .updateTable('insights')
+        .set({
           summary,
           updatedAt: now.getTime(),
         })
-      )
-      .returningAll()
-      .executeTakeFirstOrThrow()
+        // BUG: missing .where('documentId', '=', documentId)
+        .execute()
+    } else {
+      await db
+        .insertInto('insights')
+        .values({
+          documentId,
+          summary,
+          createdAt: now.getTime(),
+          updatedAt: now.getTime(),
+        })
+        .execute()
+    }
 
     return NextResponse.json({
       success: true,
-      insights: {
-        documentId: result.documentId,
-        summary: result.summary,
-        createdAt: new Date(result.createdAt).toISOString(),
-        updatedAt: new Date(result.updatedAt).toISOString(),
-      },
     })
   } catch (error) {
     console.error('Error storing insights:', error)

--- a/app/api/store-insights/route.ts
+++ b/app/api/store-insights/route.ts
@@ -17,32 +17,15 @@ export async function POST(request: NextRequest) {
 
     const now = new Date()
 
-    const existing = await db
-      .selectFrom('insights')
-      .where('documentId', '=', documentId)
-      .selectAll()
-      .executeTakeFirst()
-
-    if (existing) {
-      await db
-        .updateTable('insights')
-        .set({
-          summary,
-          updatedAt: now.getTime(),
-        })
-        // BUG: missing .where('documentId', '=', documentId)
-        .execute()
-    } else {
-      await db
-        .insertInto('insights')
-        .values({
-          documentId,
-          summary,
-          createdAt: now.getTime(),
-          updatedAt: now.getTime(),
-        })
-        .execute()
-    }
+    await db
+      .insertInto('insights')
+      .values({
+        documentId,
+        summary,
+        createdAt: now.getTime(),
+        updatedAt: now.getTime(),
+      })
+      .execute()
 
     return NextResponse.json({
       success: true,

--- a/app/documents/[id]/page.tsx
+++ b/app/documents/[id]/page.tsx
@@ -134,24 +134,9 @@ export default function DocumentPage({ params }: DocumentPageProps) {
               </Text>
             </Box>
           )}
-
+          {/* TODO: Display document content */}
           {/* TODO: Display insights once generated */}
-          {insights && (
-            <Box bg="white" rounded="lg" shadow="md" p={6}>
-              <Heading size="md" mb={4}>Insights</Heading>
-              <Stack gap={4}>
-                {/* TODO: Display summary */}
-
-                {/* TODO: Display comprehensionScore as a visual badge or progress bar */}
-
-                {/* TODO: Display isNonFiction as a label (e.g. "Fiction" or "Non-Fiction") */}
-
-                {/* TODO: Display suggestedEdits as a list where each item can be individually
-                    marked as applied. Track applied state locally with useState.
-                    Applied suggestions should look visually distinct from unapplied ones. */}
-              </Stack>
-            </Box>
-          )}
+          { insights && <Box>{JSON.stringify(insights)}</Box>}
         </Stack>
       </Container>
     </Box>

--- a/app/documents/[id]/page.tsx
+++ b/app/documents/[id]/page.tsx
@@ -135,8 +135,23 @@ export default function DocumentPage({ params }: DocumentPageProps) {
             </Box>
           )}
 
-          {/* TODO: Add insights display */}
-          <Box>{JSON.stringify(insights)}</Box>
+          {/* TODO: Display insights once generated */}
+          {insights && (
+            <Box bg="white" rounded="lg" shadow="md" p={6}>
+              <Heading size="md" mb={4}>Insights</Heading>
+              <Stack gap={4}>
+                {/* TODO: Display summary */}
+
+                {/* TODO: Display comprehensionScore as a visual badge or progress bar */}
+
+                {/* TODO: Display isNonFiction as a label (e.g. "Fiction" or "Non-Fiction") */}
+
+                {/* TODO: Display suggestedEdits as a list where each item can be individually
+                    marked as applied. Track applied state locally with useState.
+                    Applied suggestions should look visually distinct from unapplied ones. */}
+              </Stack>
+            </Box>
+          )}
         </Stack>
       </Container>
     </Box>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ export default function Home() {
   const { documents, initialized, init, addDocument } = useDocumentStore()
   const [isUploading, setIsUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  // TODO: Use this state to implement ascending/descending sort by comprehension score
+  const [sortAsc, setSortAsc] = useState(true)
 
   useEffect(() => {
     init()
@@ -93,9 +95,13 @@ export default function Home() {
 
           {/* Documents List */}
           <Box bg="white" rounded="lg" shadow="md" p={6}>
-            <Heading size="md" mb={4}>
-              Your Documents
-            </Heading>
+            <HStack justify="space-between" mb={4}>
+              <Heading size="md">Your Documents</Heading>
+              {/* TODO: Wire this button up to sortAsc state and sort the documents list */}
+              <Button size="sm" variant="outline" onClick={() => setSortAsc(!sortAsc)}>
+                Score: {sortAsc ? 'Low → High' : 'High → Low'}
+              </Button>
+            </HStack>
 
             {!initialized ? (
               <Box textAlign="center" py={8}>


### PR DESCRIPTION
- Add suggestedEdits to InsightsResponse type
- Scaffold sort button + state in home page (candidates wire it up)
- Replace JSON.stringify stub with explicit TODO sections on detail page
- Update README Part 1 to require all four fields and suggestedEdits UI
- Update README Part 2 to clarify sort button wiring task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document insights now include summary, comprehension score (0–100), fiction flag, and suggested edits; suggested edits are persisted and shown as individually markable items.
  * Added a sort toggle UI to switch document ordering by comprehension score (Low → High / High → Low).
  * Insights are displayed only after they are available.

* **Documentation**
  * README updated to reflect the expanded insights fields.

* **Bug Fixes**
  * Simplified insights save behavior and response payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->